### PR TITLE
Correctly find project templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neutrino-preset-web",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Neutrino preset for building generic web applications",
   "main": "src/index.js",
   "keywords": [

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ const config = webpackMerge(preset, {
   plugins: [
     new webpack.EnvironmentPlugin(['NODE_ENV']),
     new HtmlPlugin({
-      template: exists(PROJECT_TEMPLATE) ? PROJECT_TEMPLATE : PRESET_TEMPLATE,
+      template: exists.sync(PROJECT_TEMPLATE) ? PROJECT_TEMPLATE : PRESET_TEMPLATE,
       hash: true,
       xhtml: true
     })


### PR DESCRIPTION
Per [docs](https://www.npmjs.com/package/exists-file) exists-file is async by default, which explains why it's not finding my project template.